### PR TITLE
Navigatorの整理

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
 import 'package:chat_flutter/di.dart';
+import 'package:chat_flutter/ui/pages/add_friend.dart';
+import 'package:chat_flutter/ui/pages/create_group.dart';
 import 'package:chat_flutter/ui/pages/main.dart';
 import 'package:chat_flutter/ui/pages/profile_edit.dart';
 import 'package:chat_flutter/ui/pages/profile.dart';
+import 'package:chat_flutter/ui/pages/room.dart';
+import 'package:chat_flutter/ui/pages/sign_in.dart';
 import 'package:chat_flutter/ui/pages/sign_up.dart';
-import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 void main() {
   runApp(
@@ -29,8 +34,12 @@ class MyApp extends StatelessWidget {
       routes: {
         '/mainPage': (context) => MainPage(),
         '/signUpPage': (context) => SignUpPage(),
+        '/signInPage': (context) => SignInPage(),
+        '/roomPage': (context) => RoomPage(),
         '/profilePage': (context) => ProfilePage(),
         '/profileEditPage': (context) => ProfileEditPage(),
+        '/addFriendPage': (context) => AddFriendPage(),
+        '/createGroupPage': (context) => CreateGroupPage(),
       },
     );
   }

--- a/lib/ui/molecules/home/app_bar.dart
+++ b/lib/ui/molecules/home/app_bar.dart
@@ -19,17 +19,21 @@ class HomePageAppBar extends StatelessWidget with PreferredSizeWidget {
       actions: <Widget>[
         IconButton(
           icon: Icon(
-            Icons.add_circle_outline,
+            Icons.person_add,
           ),
           color: Color(0xff707070),
-          onPressed: () {},
+          onPressed: () {
+            Navigator.pushNamed(context, '/addFriendPage');
+          },
         ),
         IconButton(
           icon: Icon(
-            Icons.add_circle_outline,
+            Icons.group_add,
           ),
           color: Color(0xff707070),
-          onPressed: () {},
+          onPressed: () {
+            Navigator.pushNamed(context, '/createGroupPage');
+          },
         ),
       ],
     );

--- a/lib/ui/molecules/talk/list_tile.dart
+++ b/lib/ui/molecules/talk/list_tile.dart
@@ -1,6 +1,5 @@
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
-import 'package:chat_flutter/ui/pages/room.dart';
 import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/room.dart';
 
@@ -11,11 +10,8 @@ class TalkPageListTile extends StatelessWidget {
   Widget build(BuildContext context) {
     return FlatButton(
       onPressed: () {
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => RoomPage(room.name),
-          ),
+        Navigator.pushNamed(
+          context,'/roomPage',arguments: room.name,
         );
       },
       child: SizedBox(

--- a/lib/ui/molecules/talk/list_tile.dart
+++ b/lib/ui/molecules/talk/list_tile.dart
@@ -11,7 +11,9 @@ class TalkPageListTile extends StatelessWidget {
     return FlatButton(
       onPressed: () {
         Navigator.pushNamed(
-          context,'/roomPage',arguments: room.name,
+          context,
+          '/roomPage',
+          arguments: room.name,
         );
       },
       child: SizedBox(

--- a/lib/ui/pages/add_friend.dart
+++ b/lib/ui/pages/add_friend.dart
@@ -24,7 +24,7 @@ class AddFriendPage extends StatelessWidget {
             ),
           ),
         ),
-        actionsIconTheme: IconThemeData(
+        iconTheme: IconThemeData(
           color: Color(0xff707070),
         ),
         actions: <Widget>[

--- a/lib/ui/pages/create_group.dart
+++ b/lib/ui/pages/create_group.dart
@@ -21,11 +21,13 @@ class CreateGroupPage extends StatelessWidget {
           ),
         ),
         iconTheme: IconThemeData(
-          color: Colors.blue,
+          color: Color(0xff707070),
         ),
         actions: <Widget>[
           IconButton(
-            onPressed: () {},
+            onPressed: () {
+              Navigator.pop(context);
+            },
             icon: Icon(
               Icons.check,
             ),

--- a/lib/ui/pages/profile.dart
+++ b/lib/ui/pages/profile.dart
@@ -17,7 +17,7 @@ class ProfilePage extends StatelessWidget {
       future: userProvider.getUserById("userId"),
       builder: (BuildContext context, AsyncSnapshot<User> snapshot) {
         if (snapshot.hasError) {
-          return Text('Error: ${snapshot.error}');
+          return Center(child: Text('Error: ${snapshot.error}'));
         }
         switch (snapshot.connectionState) {
           case ConnectionState.waiting: // データの取得まち

--- a/lib/ui/pages/profile.dart
+++ b/lib/ui/pages/profile.dart
@@ -76,7 +76,8 @@ class _ProfilePage extends StatelessWidget {
                 ),
                 label: Text("編集する"),
                 onPressed: () {
-                  Navigator.pushNamed<void>(context, "/profileEditPage",arguments: "test");
+                  Navigator.pushNamed<void>(context, "/profileEditPage",
+                      arguments: "test");
                 },
                 color: Colors.green,
                 textColor: Colors.white,

--- a/lib/ui/pages/profile.dart
+++ b/lib/ui/pages/profile.dart
@@ -76,7 +76,7 @@ class _ProfilePage extends StatelessWidget {
                 ),
                 label: Text("編集する"),
                 onPressed: () {
-                  Navigator.pushNamed<void>(context, "/profileEditPage");
+                  Navigator.pushNamed<void>(context, "/profileEditPage",arguments: "test");
                 },
                 color: Colors.green,
                 textColor: Colors.white,

--- a/lib/ui/pages/profile.dart
+++ b/lib/ui/pages/profile.dart
@@ -76,8 +76,11 @@ class _ProfilePage extends StatelessWidget {
                 ),
                 label: Text("編集する"),
                 onPressed: () {
-                  Navigator.pushNamed<void>(context, "/profileEditPage",
-                      arguments: "test");
+                  Navigator.pushNamed<void>(
+                    context,
+                    "/profileEditPage",
+                    arguments: "test",
+                  );
                 },
                 color: Colors.green,
                 textColor: Colors.white,

--- a/lib/ui/pages/profile_edit.dart
+++ b/lib/ui/pages/profile_edit.dart
@@ -1,13 +1,13 @@
-import 'package:chat_flutter/config/app_space.dart';
-import 'package:chat_flutter/providers/user.dart';
-import 'package:chat_flutter/ui/atoms/profile_image.dart';
-import 'package:chat_flutter/ui/molecules/profile/app_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import 'package:chat_flutter/model/user.dart';
-import 'package:chat_flutter/config/app_space.dart';
+import 'package:chat_flutter/providers/user.dart';
+import 'package:chat_flutter/ui/atoms/profile_image.dart';
+import 'package:chat_flutter/ui/molecules/profile/app_bar.dart';
 
+import 'package:chat_flutter/model/user.dart';
+
+import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
 
 class ProfileEditPage extends StatelessWidget {
@@ -62,7 +62,7 @@ class _ProfileEditPage extends StatelessWidget {
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           FlatButton(
-            onPressed: (){},
+            onPressed: () {},
             child: ProfileImage(image: user.imgUrl),
           ),
           SizedBox(

--- a/lib/ui/pages/profile_edit.dart
+++ b/lib/ui/pages/profile_edit.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:chat_flutter/model/user.dart';
+import 'package:chat_flutter/config/app_space.dart';
 
 import 'package:chat_flutter/config/app_text_size.dart';
 
@@ -52,20 +53,35 @@ class _ProfileEditPage extends StatelessWidget {
   const _ProfileEditPage({Key key, this.user}) : super(key: key);
   @override
   Widget build(BuildContext context) {
+    final TextEditingController _nameController = TextEditingController(
+      text: ModalRoute.of(context).settings.arguments,
+    );
     return SafeArea(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          ProfileImage(image: user.imgUrl),
+          FlatButton(
+            onPressed: (){},
+            child: ProfileImage(image: user.imgUrl),
+          ),
           SizedBox(
             height: AppSpace.small,
           ),
-          Text(
-            user.name,
-            style: TextStyle(
-              fontSize: AppTextSize.xlarge,
-              fontWeight: FontWeight.w700,
+          Padding(
+            padding: EdgeInsets.symmetric(
+              horizontal: AppSpace.midium,
+            ),
+            child: TextField(
+              keyboardType: TextInputType.multiline,
+              minLines: 1,
+              maxLines: 1,
+              controller: _nameController,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: AppTextSize.xlarge,
+                fontWeight: FontWeight.w700,
+              ),
             ),
           ),
           SizedBox(

--- a/lib/ui/pages/room.dart
+++ b/lib/ui/pages/room.dart
@@ -6,20 +6,11 @@ import 'package:flutter/rendering.dart';
 
 import 'package:chat_flutter/config/app_text_size.dart';
 
-class RoomPage extends StatefulWidget {
-  final String name;
-  RoomPage(this.name);
-  //本来はfirebase上のIDを渡して、ルーム名を取得したい。
-  @override
-  _RoomPageState createState() => _RoomPageState(this.name);
-}
-
-class _RoomPageState extends State<RoomPage> {
-  final String name;
-  _RoomPageState(this.name);
+class RoomPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final String name = ModalRoute.of(context).settings.arguments;
     final TextEditingController _controller = TextEditingController();
     return Scaffold(
       appBar: AppBar(

--- a/lib/ui/pages/room.dart
+++ b/lib/ui/pages/room.dart
@@ -7,7 +7,6 @@ import 'package:flutter/rendering.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
 
 class RoomPage extends StatelessWidget {
-
   @override
   Widget build(BuildContext context) {
     final String name = ModalRoute.of(context).settings.arguments;

--- a/lib/ui/pages/sign_up.dart
+++ b/lib/ui/pages/sign_up.dart
@@ -1,7 +1,6 @@
 import 'package:chat_flutter/config/app_radius.dart';
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/ui/atoms/input_text_field.dart';
-import 'package:chat_flutter/ui/pages/sign_in.dart';
 import 'package:flutter/material.dart';
 
 import 'package:chat_flutter/config/app_text_size.dart';
@@ -102,12 +101,8 @@ class SignUpPage extends StatelessWidget {
                   ),
                   FlatButton(
                     onPressed: () {
-                      Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (context) {
-                            return SignInPage();
-                          },
-                        ),
+                      Navigator.of(context).pushNamed(
+                        '/signInPage',
                       );
                     },
                     child: Text(


### PR DESCRIPTION
# issue
#12 

# やったこと
- `lib/main.dart`にページルートを定義した。
- 今まで使われてきた`Navigator.push`を`Navigator.pushNamed`に修正した。
- `Navigator.pushNamed`でargumentsとしてデータを渡すようにした。

**※**`profile_edit.dart`にも変更を加えた
- `Text`を`TextField`とし、名前の入力をできるようにした。
- `ProfileImage`に`FlatButton`を親としてつけ、関数を実行できるようにした。