### PR TITLE
静的解析[lint]の設定

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,13 @@
+# https://pub.dev/packages/pedantic_mono
+include: package:pedantic_mono/analysis_options.yaml
+
+linter:
+  rules:
+    lines_longer_than_80_chars: false
+    omit_local_variable_types: false
+    flutter_style_todos: false
+    one_member_abstracts: false
+    avoid_function_literals_in_foreach_calls: false
+    non_constant_identifier_names: false
+    avoid_single_cascade_in_expression_statements: false
+    constant_identifier_names: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic_mono: any
+
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## 概要
constのつけ忘れや、その他フォーマットの静的解析を導入。
https://pub.dev/packages/pedantic_mono
を参考にしています。

この前のハッカソンでこのlintは不要だなと思ったところは `hoge: false` にして弾いています。
