### PR TITLE
プロフィール編集画面の実装の続き

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:chat_flutter/services/messgae_service.dart';
 import 'package:chat_flutter/ui/pages/create_room/select_member.dart';
 import 'package:chat_flutter/services/auth/authenticator.dart';
+import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:chat_flutter/ui/pages/sign_in/sign_in.dart';
 import 'package:chat_flutter/ui/pages/sign_up/sign_up.dart';
 import 'package:flutter/material.dart';
@@ -26,30 +27,38 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
+    // AuthenticatorをProvideしたかったので、MultiProviderではできなかった
+    return ChangeNotifierProvider(
+      create: (_) => ProfileController(
+        Provider.of<Authenticator>(
+          context,
+          listen: false,
+        ),
       ),
-      initialRoute:
-          Provider.of<Authenticator>(context, listen: false).isSignIn.value
-              ? '/homePage'
-              : '/signUpPage',
-      routes: {
-        '/homePage': HomePage.wrapped,
-        '/signUpPage': (context) => SignUpPage.wrapped(
-            Provider.of<Authenticator>(context, listen: false)),
-        '/signInPage': (context) => SignInPage.wrapped(
-            Provider.of<Authenticator>(context, listen: false)),
-        '/roomPage': RoomPage.wrapped,
-        '/profileEditPage': ProfileEditPage.wrapped,
-        '/selectMemberPage': (context) => SelectMemberPage.wrapped(),
-        '/createGroupPage': (context) => CreateRoomPage.wrapped(),
-      },
+      child: MaterialApp(
+        title: 'Flutter Demo',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+        ),
+        initialRoute:
+            Provider.of<Authenticator>(context, listen: false).isSignIn.value
+                ? '/homePage'
+                : '/signUpPage',
+        routes: {
+          '/homePage': HomePage.wrapped,
+          '/signUpPage': (context) => SignUpPage.wrapped(
+              Provider.of<Authenticator>(context, listen: false)),
+          '/signInPage': (context) => SignInPage.wrapped(
+              Provider.of<Authenticator>(context, listen: false)),
+          '/roomPage': RoomPage.wrapped,
+          '/profileEditPage': (context) => ProfileEditPage(),
+          '/selectMemberPage': (context) => SelectMemberPage.wrapped(),
+          '/createGroupPage': (context) => CreateRoomPage.wrapped(),
+        },
+      ),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,7 +29,7 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // AuthenticatorをProvideしたかったので、MultiProviderではできなかった
+    // Authenticatorをコンストラクタで渡したかったので、MultiProviderではできなかった
     return ChangeNotifierProvider(
       create: (_) => ProfileController(
         Provider.of<Authenticator>(

--- a/lib/model/user.dart
+++ b/lib/model/user.dart
@@ -1,15 +1,18 @@
 class User {
+  String id;
   String name;
   String imgUrl;
   bool isMe;
   User({
+    this.id,
     this.name,
     this.imgUrl,
     this.isMe,
   });
 
-  factory User.fromJson(Map<String, dynamic> json) {
+  factory User.fromJson(Map<String, dynamic> json, String userId) {
     return User(
+      id: userId,
       name: json['name'].toString(),
       imgUrl: json['profileImageURL'].toString(),
     );

--- a/lib/services/firebase_storage_service.dart
+++ b/lib/services/firebase_storage_service.dart
@@ -7,9 +7,9 @@ class FirebaseStorageService {
   Future<String> uploadImage(File file, String uid) async {
     final StorageReference ref = _storage.ref().child(uid);
     final StorageUploadTask uploadTask = ref.putFile(file);
-    final dynamic downurl =
+    final dynamic downLoadUrl =
         await (await uploadTask.onComplete).ref.getDownloadURL();
-    final String url = downurl.toString();
-    return url;
+    final String downLoadUrlString = downLoadUrl.toString();
+    return downLoadUrlString;
   }
 }

--- a/lib/services/firebase_storage_service.dart
+++ b/lib/services/firebase_storage_service.dart
@@ -10,9 +10,9 @@ class FirebaseStorageService {
 
     await uploadTask.onComplete;
 
-    final dynamic downLoadUrl = await ref.getDownloadURL();
-    final String downLoadUrlString = downLoadUrl.toString();
+    final dynamic downloadUrl = await ref.getDownloadURL();
+    final String downloadUrlString = downloadUrl.toString();
 
-    return downLoadUrlString;
+    return downloadUrlString;
   }
 }

--- a/lib/services/firebase_storage_service.dart
+++ b/lib/services/firebase_storage_service.dart
@@ -7,9 +7,12 @@ class FirebaseStorageService {
   Future<String> uploadImage(File file, String uid) async {
     final StorageReference ref = _storage.ref().child(uid);
     final StorageUploadTask uploadTask = ref.putFile(file);
-    final dynamic downLoadUrl =
-        await (await uploadTask.onComplete).ref.getDownloadURL();
+
+    await uploadTask.onComplete;
+
+    final dynamic downLoadUrl = await ref.getDownloadURL();
     final String downLoadUrlString = downLoadUrl.toString();
+
     return downLoadUrlString;
   }
 }

--- a/lib/services/firebase_user_service.dart
+++ b/lib/services/firebase_user_service.dart
@@ -11,14 +11,14 @@ class FirebaseUserService {
     await _db.collection('message/v1/users').document('$uid').setData(userData);
   }
 
-  Future<void> updateUserData(String name, String imgUrl, String uid) async {
+  Future<void> updateUserData(User user) async {
     final Map<String, String> userData = {
-      'name': name,
-      'profileImageURL': imgUrl,
+      'name': user.name,
+      'profileImageURL': user.imgUrl,
     };
     await _db
         .collection('message/v1/users')
-        .document('$uid')
+        .document(user.id)
         .updateData(userData);
   }
 

--- a/lib/services/firebase_user_service.dart
+++ b/lib/services/firebase_user_service.dart
@@ -26,6 +26,6 @@ class FirebaseUserService {
     final DocumentSnapshot result =
         await _db.collection('message/v1/users').document('$uid').get();
     final Map<String, dynamic> user = result.data;
-    return User.fromJson(user);
+    return User.fromJson(user, uid);
   }
 }

--- a/lib/ui/atoms/profile_image.dart
+++ b/lib/ui/atoms/profile_image.dart
@@ -1,14 +1,14 @@
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 class ProfileImage extends StatelessWidget {
-  const ProfileImage({Key key, this.size, this.profileController})
-      : super(key: key);
+  const ProfileImage({Key key, this.size}) : super(key: key);
   final double size;
-  final ProfileController profileController;
 
   @override
   Widget build(BuildContext context) {
+    final profileController = Provider.of<ProfileController>(context);
     if (profileController.selectedImageFile != null) {
       return SizedBox(
         width: size,

--- a/lib/ui/atoms/profile_image.dart
+++ b/lib/ui/atoms/profile_image.dart
@@ -9,12 +9,12 @@ class ProfileImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (profileController.image != null) {
+    if (profileController.selectedImageFile != null) {
       return SizedBox(
         width: size,
         height: size,
         child: CircleAvatar(
-          backgroundImage: FileImage(profileController.image),
+          backgroundImage: FileImage(profileController.selectedImageFile),
         ),
       );
     } else if (profileController.user.imgUrl != '' &&

--- a/lib/ui/atoms/profile_image.dart
+++ b/lib/ui/atoms/profile_image.dart
@@ -1,14 +1,14 @@
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 class ProfileImage extends StatelessWidget {
-  const ProfileImage({Key key, this.size}) : super(key: key);
+  const ProfileImage({Key key, this.size, this.profileController})
+      : super(key: key);
   final double size;
+  final ProfileController profileController;
 
   @override
   Widget build(BuildContext context) {
-    final profileController = Provider.of<ProfileController>(context);
     if (profileController.image != null) {
       return SizedBox(
         width: size,
@@ -17,7 +17,8 @@ class ProfileImage extends StatelessWidget {
           backgroundImage: FileImage(profileController.image),
         ),
       );
-    } else if (profileController.user.imgUrl != '') {
+    } else if (profileController.user.imgUrl != '' &&
+        profileController.user.imgUrl != null) {
       return Container(
         width: size,
         height: size,

--- a/lib/ui/pages/home/home.dart
+++ b/lib/ui/pages/home/home.dart
@@ -3,7 +3,6 @@ import 'package:chat_flutter/ui/molecules/profile/app_bar.dart';
 import 'package:chat_flutter/ui/molecules/talk/app_bar.dart';
 import 'package:chat_flutter/ui/pages/home/home_controller.dart';
 import 'package:chat_flutter/ui/pages/profile/profile.dart';
-import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:chat_flutter/ui/pages/talk/talk.dart';
 import 'package:chat_flutter/ui/pages/talk/talk_controller.dart';
 import 'package:flutter/material.dart';
@@ -25,14 +24,6 @@ class HomePage extends StatelessWidget {
         ),
         ChangeNotifierProvider<TalkController>(
           create: (_) => TalkController(),
-        ),
-        ChangeNotifierProvider<ProfileController>(
-          create: (_) => ProfileController(
-            Provider.of<Authenticator>(
-              context,
-              listen: false,
-            ),
-          ),
         ),
       ],
       child: const HomePage._(),

--- a/lib/ui/pages/profile/profile.dart
+++ b/lib/ui/pages/profile/profile.dart
@@ -94,7 +94,7 @@ class _ProfilePage extends StatelessWidget {
             child: const Text('更新'),
             onPressed: () =>
                 Provider.of<ProfileController>(context, listen: false)
-                    .getUserById('Kh2FY47Y0kak7zWB9bE7zY7FkCH3'),
+                    .getUserById(),
           ),
         ],
       ),

--- a/lib/ui/pages/profile/profile.dart
+++ b/lib/ui/pages/profile/profile.dart
@@ -87,11 +87,6 @@ class _ProfilePage extends StatelessWidget {
               ),
             ),
           ),
-          RaisedButton(
-              child: const Text('更新'),
-              onPressed: () =>
-                  Provider.of<ProfileController>(context, listen: false)
-                      .getUserById),
         ],
       ),
     );

--- a/lib/ui/pages/profile/profile.dart
+++ b/lib/ui/pages/profile/profile.dart
@@ -3,29 +3,26 @@ import 'package:chat_flutter/ui/atoms/profile_image.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-
-import 'package:chat_flutter/model/user.dart';
-
 import 'package:chat_flutter/config/app_text_size.dart';
 
 class ProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final user = Provider.of<ProfileController>(context).user;
-    if (user == null) {
+    final profileController = Provider.of<ProfileController>(context);
+    if (profileController.user == null) {
       return const Center(
         child: CircularProgressIndicator(),
       );
     } else {
-      return _ProfilePage(user: user);
+      return _ProfilePage(controller: profileController);
     }
   }
 }
 
 class _ProfilePage extends StatelessWidget {
-  final User user;
+  final ProfileController controller;
 
-  const _ProfilePage({Key key, this.user}) : super(key: key);
+  const _ProfilePage({Key key, this.controller}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -34,14 +31,15 @@ class _ProfilePage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          const ProfileImage(
+          ProfileImage(
+            profileController: controller,
             size: 150,
           ),
           const SizedBox(
             height: AppSpace.small,
           ),
           Text(
-            user.name,
+            controller.user.name,
             style: const TextStyle(
               fontSize: AppTextSize.xlarge,
               fontWeight: FontWeight.w700,
@@ -63,7 +61,6 @@ class _ProfilePage extends StatelessWidget {
                   Navigator.pushNamed<void>(
                     context,
                     '/profileEditPage',
-                    arguments: user.name,
                   );
                 },
                 color: Colors.green,
@@ -91,11 +88,10 @@ class _ProfilePage extends StatelessWidget {
             ),
           ),
           RaisedButton(
-            child: const Text('更新'),
-            onPressed: () =>
-                Provider.of<ProfileController>(context, listen: false)
-                    .getUserById(),
-          ),
+              child: const Text('更新'),
+              onPressed: () =>
+                  Provider.of<ProfileController>(context, listen: false)
+                      .getUserById),
         ],
       ),
     );

--- a/lib/ui/pages/profile/profile.dart
+++ b/lib/ui/pages/profile/profile.dart
@@ -1,4 +1,5 @@
 import 'package:chat_flutter/config/app_space.dart';
+import 'package:chat_flutter/model/user.dart';
 import 'package:chat_flutter/ui/atoms/profile_image.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
@@ -8,21 +9,21 @@ import 'package:chat_flutter/config/app_text_size.dart';
 class ProfilePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final profileController = Provider.of<ProfileController>(context);
-    if (profileController.user == null) {
+    final user = Provider.of<ProfileController>(context).user;
+    if (user == null) {
       return const Center(
         child: CircularProgressIndicator(),
       );
     } else {
-      return _ProfilePage(controller: profileController);
+      return _ProfilePage(user: user);
     }
   }
 }
 
 class _ProfilePage extends StatelessWidget {
-  final ProfileController controller;
+  final User user;
 
-  const _ProfilePage({Key key, this.controller}) : super(key: key);
+  const _ProfilePage({Key key, this.user}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -31,15 +32,14 @@ class _ProfilePage extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.center,
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
-          ProfileImage(
-            profileController: controller,
+          const ProfileImage(
             size: 150,
           ),
           const SizedBox(
             height: AppSpace.small,
           ),
           Text(
-            controller.user.name,
+            user.name,
             style: const TextStyle(
               fontSize: AppTextSize.xlarge,
               fontWeight: FontWeight.w700,

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -39,7 +39,6 @@ class ProfileController with ChangeNotifier {
   Future<void> changeProfileInfo(String name) async {
     final FirebaseStorageService firebaseStorageService =
         FirebaseStorageService();
-    final FirebaseUserService firebaseUserService = FirebaseUserService();
     user.name = name;
     if (image != null) {
       user.imgUrl = await firebaseStorageService.uploadImage(
@@ -47,11 +46,7 @@ class ProfileController with ChangeNotifier {
         user.id,
       );
     }
-    await firebaseUserService.updateUserData(
-      user.name,
-      user.imgUrl,
-      user.id,
-    );
+    await firebaseUserService.updateUserData(user);
     image = null;
     notifyListeners();
   }

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -12,7 +12,7 @@ class ProfileController with ChangeNotifier {
     getUserById();
   }
   User user;
-  File image;
+  File selectedImageFile;
   Authenticator authenticator;
   FirebaseUserService firebaseUserService = FirebaseUserService();
 
@@ -24,30 +24,28 @@ class ProfileController with ChangeNotifier {
 
   Future<void> selectProfileImage() async {
     final imagePicker = ImagePicker();
-    final selectImage = await imagePicker.getImage(source: ImageSource.gallery);
-    if (selectImage != null) {
-      image = File(selectImage.path);
+    final selectedImage = await imagePicker.getImage(source: ImageSource.gallery);
+    if (selectedImage != null) {
+      selectedImageFile = File(selectedImage.path);
       notifyListeners();
     }
   }
 
   void notifySelectImage(String imagePath) {
-    image = File(imagePath);
+    selectedImageFile = File(imagePath);
     notifyListeners();
   }
 
   Future<void> changeProfileInfo(String name) async {
-    final FirebaseStorageService firebaseStorageService =
-        FirebaseStorageService();
     user.name = name;
-    if (image != null) {
-      user.imgUrl = await firebaseStorageService.uploadImage(
-        image,
+    if (selectedImageFile != null) {
+      user.imgUrl = await FirebaseStorageService().uploadImage(
+        selectedImageFile,
         user.id,
       );
     }
     await firebaseUserService.updateUserData(user);
-    image = null;
+    selectedImageFile = null;
     notifyListeners();
   }
 

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -9,15 +9,15 @@ import 'package:image_picker/image_picker.dart';
 
 class ProfileController with ChangeNotifier {
   ProfileController(this.authenticator) {
-    //TODO:仮ID削除
-    getUserById('Kh2FY47Y0kak7zWB9bE7zY7FkCH3');
+    getUserById();
   }
   User user;
   File image;
   Authenticator authenticator;
   FirebaseUserService firebaseUserService = FirebaseUserService();
 
-  Future<void> getUserById(String userId) async {
+  Future<void> getUserById() async {
+    final String userId = await authenticator.getUid();
     user = await firebaseUserService.getUserData(userId);
     notifyListeners();
   }
@@ -44,13 +44,13 @@ class ProfileController with ChangeNotifier {
     if (image != null) {
       user.imgUrl = await firebaseStorageService.uploadImage(
         image,
-        'Kh2FY47Y0kak7zWB9bE7zY7FkCH3',
+        user.id,
       );
     }
     await firebaseUserService.updateUserData(
       user.name,
       user.imgUrl,
-      'Kh2FY47Y0kak7zWB9bE7zY7FkCH3',
+      user.id,
     );
     image = null;
     notifyListeners();

--- a/lib/ui/pages/profile/profile_controller.dart
+++ b/lib/ui/pages/profile/profile_controller.dart
@@ -24,7 +24,8 @@ class ProfileController with ChangeNotifier {
 
   Future<void> selectProfileImage() async {
     final imagePicker = ImagePicker();
-    final selectedImage = await imagePicker.getImage(source: ImageSource.gallery);
+    final selectedImage =
+        await imagePicker.getImage(source: ImageSource.gallery);
     if (selectedImage != null) {
       selectedImageFile = File(selectedImage.path);
       notifyListeners();

--- a/lib/ui/pages/profile/profile_edit.dart
+++ b/lib/ui/pages/profile/profile_edit.dart
@@ -67,8 +67,7 @@ class _ProfileEditPage extends StatelessWidget {
                 );
               }
             },
-            child: ProfileImage(
-              profileController: profileController,
+            child: const ProfileImage(
               size: 150,
             ),
           ),

--- a/lib/ui/pages/profile/profile_edit.dart
+++ b/lib/ui/pages/profile/profile_edit.dart
@@ -1,34 +1,15 @@
-import 'package:chat_flutter/services/auth/authenticator.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
-
 import 'package:chat_flutter/ui/atoms/profile_image.dart';
-
-import 'package:chat_flutter/model/user.dart';
-
 import 'package:chat_flutter/config/app_space.dart';
 import 'package:chat_flutter/config/app_text_size.dart';
 
 class ProfileEditPage extends StatelessWidget {
-  const ProfileEditPage._({Key key}) : super(key: key);
-
-  static Widget wrapped(BuildContext context) {
-    return ChangeNotifierProvider<ProfileController>(
-      create: (_) => ProfileController(
-        Provider.of<Authenticator>(
-          context,
-          listen: false,
-        ),
-      ),
-      child: const ProfileEditPage._(),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    final user = Provider.of<ProfileController>(context).user;
+    final controller = Provider.of<ProfileController>(context);
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -43,28 +24,28 @@ class ProfileEditPage extends StatelessWidget {
         ),
       ),
       backgroundColor: Colors.white,
-      body: (user == null)
+      body: (controller.user == null)
           ? const Center(
               child: CircularProgressIndicator(),
             )
           : _ProfileEditPage(
-              user: user,
+              controller: controller,
             ),
     );
   }
 }
 
 class _ProfileEditPage extends StatelessWidget {
-  final User user;
+  final ProfileController controller;
 
-  const _ProfileEditPage({Key key, this.user}) : super(key: key);
+  const _ProfileEditPage({Key key, this.controller}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final profileController =
         Provider.of<ProfileController>(context, listen: false);
     final TextEditingController nameController = TextEditingController(
-      text: user.name,
+      text: controller.user.name,
     );
     return SafeArea(
       child: Column(
@@ -86,7 +67,8 @@ class _ProfileEditPage extends StatelessWidget {
                 );
               }
             },
-            child: const ProfileImage(
+            child: ProfileImage(
+              profileController: profileController,
               size: 150,
             ),
           ),

--- a/lib/ui/pages/profile/profile_edit.dart
+++ b/lib/ui/pages/profile/profile_edit.dart
@@ -1,3 +1,4 @@
+import 'package:chat_flutter/model/user.dart';
 import 'package:chat_flutter/ui/pages/profile/profile_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
@@ -9,7 +10,7 @@ import 'package:chat_flutter/config/app_text_size.dart';
 class ProfileEditPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final controller = Provider.of<ProfileController>(context);
+    final user = Provider.of<ProfileController>(context).user;
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -24,28 +25,28 @@ class ProfileEditPage extends StatelessWidget {
         ),
       ),
       backgroundColor: Colors.white,
-      body: (controller.user == null)
+      body: (user == null)
           ? const Center(
               child: CircularProgressIndicator(),
             )
           : _ProfileEditPage(
-              controller: controller,
+              user: user,
             ),
     );
   }
 }
 
 class _ProfileEditPage extends StatelessWidget {
-  final ProfileController controller;
+  final User user;
 
-  const _ProfileEditPage({Key key, this.controller}) : super(key: key);
+  const _ProfileEditPage({Key key, this.user}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     final profileController =
         Provider.of<ProfileController>(context, listen: false);
     final TextEditingController nameController = TextEditingController(
-      text: controller.user.name,
+      text: user.name,
     );
     return SafeArea(
       child: Column(


### PR DESCRIPTION
## 実装内容
・新規登録・ログインしたユーザー情報を引き継ぐように変更
・プロフィール編集画面での変更内容をプロフィール画面にリアルタイム更新
#44 

## 細かい内容
・仮IDをAuthticatorから取得するように変更
・MaterialApp直上でProfileControllerをProvideするように変更
・引数の渡し方を調整
・変数名の調整
・ProfileImageの条件調整
・更新ボタンが不要になったので削除

## 注意点
MaterialApp直上でProfilleControllerをProvideする方法しか思いつかなかったのですが、いい方法があれば教えてください