### PR TITLE
room(グループ)の作成機能(Firestoreから取得・UI反映)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -55,7 +55,8 @@ class MyApp extends StatelessWidget {
               Provider.of<Authenticator>(context, listen: false)),
           '/roomPage': RoomPage.wrapped,
           '/profileEditPage': (context) => ProfileEditPage(),
-          '/selectMemberPage': (context) => SelectMemberPage.wrapped(),
+          '/selectMemberPage': (context) => SelectMemberPage.wrapped(
+              Provider.of<Authenticator>(context, listen: false)),
           '/createGroupPage': (context) => CreateRoomPage.wrapped(
               Provider.of<Authenticator>(context, listen: false)),
         },

--- a/lib/model/room.dart
+++ b/lib/model/room.dart
@@ -14,4 +14,15 @@ class Room {
     this.lastMessage,
     this.sendTime,
   });
+
+  factory Room.fromJson(Map<String, dynamic> json, String roomId) {
+    return Room(
+      id: roomId,
+      name: json['name'].toString(),
+      imgUrl: json['ImgUrl'].toString(),
+      members: json['members'] as List<String>,
+      lastMessage: json['lastMessage'].toString(),
+      sendTime: json['sendTime'].toString(),
+    );
+  }
 }

--- a/lib/model/room.dart
+++ b/lib/model/room.dart
@@ -19,8 +19,8 @@ class Room {
     return Room(
       id: roomId,
       name: json['name'].toString(),
-      imgUrl: json['ImgUrl'].toString(),
-      members: json['members'] as List<String>,
+      imgUrl: json['imgUrl'].toString(),
+      members: json['members'].cast<String>() as List<String>,
       lastMessage: json['lastMessage'].toString(),
       sendTime: json['sendTime'].toString(),
     );

--- a/lib/services/firebase_room_service.dart
+++ b/lib/services/firebase_room_service.dart
@@ -26,4 +26,19 @@ class FirebaseRoomService {
         .document(roomId)
         .setData(settingData);
   }
+
+  Future getStreamSnapshot(String uid) async {
+    final QuerySnapshot querySnapshot = await _db
+        .collection('message/v1/users/$uid/room_setting')
+        .getDocuments();
+    final List<DocumentSnapshot> docList = querySnapshot.documents;
+    final List<String> roomIdList =
+        docList.map((doc) => doc.documentID).toList();
+    final List roomList = roomIdList.map((roomId) async {
+      final DocumentSnapshot room =
+          await _db.collection('message/v1/rooms/$roomId').document().get();
+      return Room.fromJson(room.data, roomId);
+    }).toList();
+    return roomList;
+  }
 }

--- a/lib/services/firebase_room_service.dart
+++ b/lib/services/firebase_room_service.dart
@@ -27,20 +27,6 @@ class FirebaseRoomService {
         .setData(settingData);
   }
 
-  /*Future getStreamSnapshot(String uid) async {
-    final QuerySnapshot querySnapshot = await _db
-        .collection('message/v1/users/$uid/room_setting')
-        .getDocuments();
-    final List<DocumentSnapshot> docList = querySnapshot.documents;
-    final List<String> roomIdList =
-        docList.map((doc) => doc.documentID).toList();
-    final List roomList = roomIdList.map((roomId) async {
-      final DocumentSnapshot room =
-          await _db.collection('message/v1/rooms/$roomId').document().get();
-      return Room.fromJson(room.data, roomId);
-    }).toList();
-    return roomList;
-  }*/
   Stream<List<Future<Room>>> getStreamSnapshot(String uid) {
     final Stream<QuerySnapshot> querySnapshot = _db
         .collection('message/v1/users/$uid/room_setting')
@@ -52,5 +38,20 @@ class FirebaseRoomService {
         });
       }).toList();
     });
+  }
+
+  Future<List<Future<Room>>> getMyRoomList(String uid) async {
+    final QuerySnapshot querySnapshot = await _db
+        .collection('message/v1/users/$uid/room_setting')
+        .getDocuments();
+    final List<DocumentSnapshot> docList = querySnapshot.documents;
+    final List<String> roomIdList =
+        docList.map((doc) => doc.documentID).toList();
+    final List<Future<Room>> roomList = roomIdList.map((roomId) async {
+      final DocumentSnapshot room =
+          await _db.collection('message/v1/rooms').document('$roomId').get();
+      return Room.fromJson(room.data, roomId);
+    }).toList();
+    return roomList;
   }
 }

--- a/lib/services/firebase_room_service.dart
+++ b/lib/services/firebase_room_service.dart
@@ -27,7 +27,7 @@ class FirebaseRoomService {
         .setData(settingData);
   }
 
-  Future getStreamSnapshot(String uid) async {
+  /*Future getStreamSnapshot(String uid) async {
     final QuerySnapshot querySnapshot = await _db
         .collection('message/v1/users/$uid/room_setting')
         .getDocuments();
@@ -40,5 +40,17 @@ class FirebaseRoomService {
       return Room.fromJson(room.data, roomId);
     }).toList();
     return roomList;
+  }*/
+  Stream<List<Future<Room>>> getStreamSnapshot(String uid) {
+    final Stream<QuerySnapshot> querySnapshot = _db
+        .collection('message/v1/users/$uid/room_setting')
+        .snapshots();
+    return querySnapshot.map((snapshot) {
+      return snapshot.documents.map((doc) {
+        return _db.collection('message/v1/rooms').document(doc.documentID).get().then((roomDoc) {
+          return Room.fromJson(roomDoc.data, doc.documentID);
+        });
+      }).toList();
+    });
   }
 }

--- a/lib/services/firebase_room_service.dart
+++ b/lib/services/firebase_room_service.dart
@@ -28,12 +28,15 @@ class FirebaseRoomService {
   }
 
   Stream<List<Future<Room>>> getStreamSnapshot(String uid) {
-    final Stream<QuerySnapshot> querySnapshot = _db
-        .collection('message/v1/users/$uid/room_setting')
-        .snapshots();
+    final Stream<QuerySnapshot> querySnapshot =
+        _db.collection('message/v1/users/$uid/room_setting').snapshots();
     return querySnapshot.map((snapshot) {
       return snapshot.documents.map((doc) {
-        return _db.collection('message/v1/rooms').document(doc.documentID).get().then((roomDoc) {
+        return _db
+            .collection('message/v1/rooms')
+            .document(doc.documentID)
+            .get()
+            .then((roomDoc) {
           return Room.fromJson(roomDoc.data, doc.documentID);
         });
       }).toList();

--- a/lib/ui/molecules/talk/list_tile.dart
+++ b/lib/ui/molecules/talk/list_tile.dart
@@ -13,8 +13,8 @@ class TalkPageListTile extends StatelessWidget {
     return FutureBuilder(
       future: room,
       builder: (BuildContext context, AsyncSnapshot<Room> snapshot) {
-        if(!snapshot.hasData){
-          return Container();
+        if (!snapshot.hasData) {
+          return const SizedBox();
         }
         return FlatButton(
           onPressed: () {

--- a/lib/ui/molecules/talk/list_tile.dart
+++ b/lib/ui/molecules/talk/list_tile.dart
@@ -4,84 +4,92 @@ import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/room.dart';
 
 class TalkPageListTile extends StatelessWidget {
-  final Room room;
+  final Future<Room> room;
 
   const TalkPageListTile(this.room);
 
   @override
   Widget build(BuildContext context) {
-    return FlatButton(
-      onPressed: () {
-        Navigator.pushNamed(
-          context,
-          '/roomPage',
-          arguments: room,
-        );
-      },
-      child: SizedBox(
-        child: Padding(
-          padding: const EdgeInsets.all(AppSpace.small),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: <Widget>[
-              SizedBox(
-                height: 60,
-                width: 60,
-                child: CircleAvatar(
-                  radius: double.infinity,
-                  backgroundImage: NetworkImage(room.imgUrl),
-                ),
-              ),
-              const SizedBox(
-                width: AppSpace.midium,
-              ),
-              SizedBox(
-                height: 60,
-                width: MediaQuery.of(context).size.width - 135,
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: <Widget>[
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      crossAxisAlignment: CrossAxisAlignment.center,
+    return FutureBuilder(
+      future: room,
+      builder: (BuildContext context, AsyncSnapshot<Room> snapshot) {
+        if(!snapshot.hasData){
+          return Container();
+        }
+        return FlatButton(
+          onPressed: () {
+            Navigator.pushNamed(
+              context,
+              '/roomPage',
+              arguments: snapshot.data,
+            );
+          },
+          child: SizedBox(
+            child: Padding(
+              padding: const EdgeInsets.all(AppSpace.small),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: <Widget>[
+                  SizedBox(
+                    height: 60,
+                    width: 60,
+                    child: CircleAvatar(
+                      radius: double.infinity,
+                      backgroundImage: NetworkImage(snapshot.data.imgUrl),
+                    ),
+                  ),
+                  const SizedBox(
+                    width: AppSpace.midium,
+                  ),
+                  SizedBox(
+                    height: 60,
+                    width: MediaQuery.of(context).size.width - 135,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: <Widget>[
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          children: <Widget>[
+                            Flexible(
+                              child: Text(
+                                snapshot.data.name,
+                                style: const TextStyle(
+                                  fontSize: AppTextSize.midium,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                            Text(
+                              snapshot.data.sendTime,
+                              style: const TextStyle(
+                                fontSize: AppTextSize.xsmall,
+                                color: Colors.grey,
+                              ),
+                            ),
+                          ],
+                        ),
                         Flexible(
                           child: Text(
-                            room.name,
-                            style: TextStyle(
-                              fontSize: AppTextSize.midium,
-                              fontWeight: FontWeight.bold,
+                            snapshot.data.lastMessage,
+                            style: const TextStyle(
+                              fontSize: AppTextSize.small,
+                              color: Colors.grey,
                             ),
                             overflow: TextOverflow.ellipsis,
                           ),
                         ),
-                        Text(
-                          room.sendTime,
-                          style: TextStyle(
-                            fontSize: AppTextSize.xsmall,
-                            color: Colors.grey,
-                          ),
-                        ),
                       ],
                     ),
-                    Flexible(
-                      child: Text(
-                        room.lastMessage,
-                        style: TextStyle(
-                          fontSize: AppTextSize.small,
-                          color: Colors.grey,
-                        ),
-                        overflow: TextOverflow.ellipsis,
-                      ),
-                    ),
-                  ],
-                ),
+                  ),
+                ],
               ),
-            ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/pages/home/home.dart
+++ b/lib/ui/pages/home/home.dart
@@ -23,7 +23,12 @@ class HomePage extends StatelessWidget {
           ),
         ),
         ChangeNotifierProvider<TalkController>(
-          create: (_) => TalkController(),
+          create: (_) => TalkController(
+            Provider.of<Authenticator>(
+              context,
+              listen: false,
+            ),
+          ),
         ),
       ],
       child: const HomePage._(),

--- a/lib/ui/pages/talk/talk.dart
+++ b/lib/ui/pages/talk/talk.dart
@@ -7,28 +7,22 @@ import 'package:provider/provider.dart';
 class TalkPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder(
-      stream: Provider.of<TalkController>(context).getStreamSnapshot(),
-      builder: (BuildContext context, AsyncSnapshot<List<Future<Room>>> snapshot) {
-        if (snapshot.hasData) {
-          return ListView.builder(
-            physics: const ScrollPhysics(),
-            scrollDirection: Axis.vertical,
-            shrinkWrap: true,
-            itemCount: snapshot.data.length,
-            itemBuilder: (
-              BuildContext context,
-              int index,
-            ) {
-              return TalkPageListTile(snapshot.data[index]);
-            },
-          );
-        }
-        else{
-          return const Center(
-            child: CircularProgressIndicator(),
-          );
-        }
+    final List<Future<Room>> roomList = Provider.of<TalkController>(context).roomList;
+    if (roomList == null) {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
+    return ListView.builder(
+      physics: const ScrollPhysics(),
+      scrollDirection: Axis.vertical,
+      shrinkWrap: true,
+      itemCount: roomList.length,
+      itemBuilder: (
+        BuildContext context,
+        int index,
+      ) {
+        return TalkPageListTile(roomList[index]);
       },
     );
   }

--- a/lib/ui/pages/talk/talk.dart
+++ b/lib/ui/pages/talk/talk.dart
@@ -1,3 +1,4 @@
+import 'package:chat_flutter/model/room.dart';
 import 'package:chat_flutter/ui/molecules/talk/list_tile.dart';
 import 'package:chat_flutter/ui/pages/talk/talk_controller.dart';
 import 'package:flutter/material.dart';
@@ -6,24 +7,29 @@ import 'package:provider/provider.dart';
 class TalkPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final roomList = Provider.of<TalkController>(context).roomList;
-    if (roomList == null) {
-      return const Center(
-        child: CircularProgressIndicator(),
-      );
-    } else {
-      return ListView.builder(
-        physics: const ScrollPhysics(),
-        scrollDirection: Axis.vertical,
-        shrinkWrap: true,
-        itemCount: roomList.length,
-        itemBuilder: (
-          BuildContext context,
-          int index,
-        ) {
-          return TalkPageListTile(roomList[index]);
-        },
-      );
-    }
+    return StreamBuilder(
+      stream: Provider.of<TalkController>(context).getStreamSnapshot(),
+      builder: (BuildContext context, AsyncSnapshot<List<Future<Room>>> snapshot) {
+        if (snapshot.hasData) {
+          return ListView.builder(
+            physics: const ScrollPhysics(),
+            scrollDirection: Axis.vertical,
+            shrinkWrap: true,
+            itemCount: snapshot.data.length,
+            itemBuilder: (
+              BuildContext context,
+              int index,
+            ) {
+              return TalkPageListTile(snapshot.data[index]);
+            },
+          );
+        }
+        else{
+          return const Center(
+            child: CircularProgressIndicator(),
+          );
+        }
+      },
+    );
   }
 }

--- a/lib/ui/pages/talk/talk.dart
+++ b/lib/ui/pages/talk/talk.dart
@@ -7,7 +7,8 @@ import 'package:provider/provider.dart';
 class TalkPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final List<Future<Room>> roomList = Provider.of<TalkController>(context).roomList;
+    final List<Future<Room>> roomList =
+        Provider.of<TalkController>(context).roomList;
     if (roomList == null) {
       return const Center(
         child: CircularProgressIndicator(),

--- a/lib/ui/pages/talk/talk_controller.dart
+++ b/lib/ui/pages/talk/talk_controller.dart
@@ -5,7 +5,7 @@ import 'package:chat_flutter/model/room.dart';
 
 class TalkController with ChangeNotifier {
   TalkController(this.authenticator) {
-    Future(() async{
+    Future(() async {
       uid = await authenticator.getUid();
       roomList = await firebaseRoomService.getMyRoomList(uid);
       notifyListeners();

--- a/lib/ui/pages/talk/talk_controller.dart
+++ b/lib/ui/pages/talk/talk_controller.dart
@@ -1,36 +1,20 @@
+import 'package:chat_flutter/services/auth/authenticator.dart';
+import 'package:chat_flutter/services/firebase_room_service.dart';
 import 'package:flutter/material.dart';
 import 'package:chat_flutter/model/room.dart';
 
 class TalkController with ChangeNotifier {
-  TalkController() {
-    getRoomList();
+  TalkController(this.authenticator) {
+    Future(() async{
+      uid = await authenticator.getUid();
+      notifyListeners();
+    });
   }
-  List<Room> roomList;
-  Future<void> getRoomList() async {
-    roomList = [
-      Room(
-        id: 'roomId',
-        name: 'Sport',
-        imgUrl: 'https://prtimes.jp/i/24101/70/resize/d24101-70-320114-0.jpg',
-        lastMessage: 'hello,group!',
-        sendTime: '23:04',
-      ),
-      Room(
-        id: 'roomId',
-        name: 'Study',
-        imgUrl: 'https://prtimes.jp/i/24101/70/resize/d24101-70-320114-0.jpg',
-        lastMessage: 'hey!',
-        sendTime: '21:04',
-      ),
-      Room(
-        id: 'roomId',
-        name: 'Hobby',
-        imgUrl: 'https://prtimes.jp/i/24101/70/resize/d24101-70-320114-0.jpg',
-        lastMessage: 'amusement Park!!!!',
-        sendTime: '20:04',
-      ),
-    ];
-    await Future<dynamic>.delayed(const Duration(seconds: 1));
-    notifyListeners();
+  final FirebaseRoomService firebaseRoomService = FirebaseRoomService();
+  Authenticator authenticator;
+  String uid;
+
+  Stream<List<Future<Room>>> getStreamSnapshot() {
+    return firebaseRoomService.getStreamSnapshot(uid);
   }
 }

--- a/lib/ui/pages/talk/talk_controller.dart
+++ b/lib/ui/pages/talk/talk_controller.dart
@@ -7,14 +7,13 @@ class TalkController with ChangeNotifier {
   TalkController(this.authenticator) {
     Future(() async{
       uid = await authenticator.getUid();
+      roomList = await firebaseRoomService.getMyRoomList(uid);
       notifyListeners();
     });
   }
+
   final FirebaseRoomService firebaseRoomService = FirebaseRoomService();
   Authenticator authenticator;
   String uid;
-
-  Stream<List<Future<Room>>> getStreamSnapshot() {
-    return firebaseRoomService.getStreamSnapshot(uid);
-  }
+  List<Future<Room>> roomList;
 }


### PR DESCRIPTION
## 実装内容
トークページにuidに対応するルームリストを表示するプログラムを作成した。
## 関連issue
#46 

## 詳細内容
`firebaseRoomService`に`List<Future<Room>>`を返す関数を作成した。
それを読み込んでtalkページに一覧を表示している。

## 注意点
`List<Room>`ではなく、`List<Future<Room>>`を返す方法になっているため、
`lib/ui/molecules/talk/list_tile.dart `での`FutureBuilder`の使い方について詳しく見てもらいたい。
